### PR TITLE
V0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,29 @@
           });
         };
 
+        // img.onerror = () => {
+        //   console.error("Failed to load image from IPFS");
+        //   alert("Failed to load image from IPFS");
+        // };
         img.onerror = () => {
-          console.error("Failed to load image from IPFS");
-          alert("Failed to load image from IPFS");
+          console.error("Failed to load image from IPFS, falling back to plain QR code.");
+          // Fallback: render plain QR code
+          new QRCodeRenderer(this.canvas, this.data, {
+            margin: 2,
+            color: {
+              dark: "#00FF00",
+              light: "#121212"
+            }
+          // }).render(callback);
+          }).render(() => {
+            // Download PNG after rendering fallback QR code
+            setTimeout(() => {
+              const link = document.createElement("a");
+              link.download = "viralqrcode.png";
+              link.href = this.canvas.toDataURL("image/png");
+              link.click();
+            }, 200);
+          });
         };
       }
     }

--- a/index.html
+++ b/index.html
@@ -46,6 +46,15 @@
       }
     }
 
+    async function blobToCID(blob) {
+      const buffer = await blob.arrayBuffer();
+      const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+      // Convert hash buffer to hex string
+      return Array.from(new Uint8Array(hashBuffer))
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join('');
+    }
+
     class ImageBackgroundQRCodeRenderer extends QRCodeRenderer {
       constructor(canvas, data, imageUrl, options = {}) {
         super(canvas, data, options);
@@ -109,8 +118,7 @@
         };
 
         img.onerror = () => {
-          console.error("Failed to load image from IPFS, falling back to plain QR code.");
-          // Fallback: render plain QR code
+          // Just fallback to plain QR code, no error message or alert
           new QRCodeRenderer(this.canvas, this.data, {
             margin: 2,
             color: {
@@ -119,6 +127,18 @@
             }
           }).render((callback) => this.download());
         };
+      }
+
+      async redirect() {
+        this.canvas.toBlob(async (blob) => {
+          if (blob) {
+            const newCid = await blobToCID(blob);
+            console.log("New CID:", newCid);
+            const newUrl = `${window.location.origin}?id=${encodeURIComponent(newCid)}&src=${encodeURIComponent(this.data)}`;            console.log("New URL:", newUrl);
+            // // Redirect to the new URL
+            window.location.href = newUrl;
+          }
+        }, "image/png");
       }
     }
 
@@ -138,7 +158,7 @@
         });
         qr.render(() => qr.download());
       } else {
-        new ImageBackgroundQRCodeRenderer(
+        const qr = new ImageBackgroundQRCodeRenderer(
           canvas,
           data,
           `https://ipfs.io/ipfs/${cid}`,
@@ -149,7 +169,8 @@
               light: '#00000000'
             }
           }
-        ).render(); // Do not call download if the canvas is tainted
+        );
+        qr.render(() => qr.redirect());
       }
     };
   </script>

--- a/index.html
+++ b/index.html
@@ -134,7 +134,8 @@
           if (blob) {
             const newCid = await blobToCID(blob);
             console.log("New CID:", newCid);
-            const newUrl = `${window.location.origin}?cid=${encodeURIComponent(newCid)}&src=${encodeURIComponent(this.data)}`;            console.log("New URL:", newUrl);
+            const newUrl = `${window.location.origin}?cid=${encodeURIComponent(newCid)}&ref=${btoa(this.data)}`;
+            console.log("New URL:", newUrl);
             // Make a dramatic pause and then redirect to the new URL
             setTimeout(() => {
               window.location.href = newUrl;

--- a/index.html
+++ b/index.html
@@ -46,42 +46,50 @@
       render(callback) {
         const ctx = this.canvas.getContext("2d");
         const img = new Image();
+        img.crossOrigin = "anonymous"; // prevent CORS tainting (optional but recommended)
         img.src = this.imageUrl;
 
         img.onload = () => {
-          const maxSize = 3000;
-          const size = Math.max(img.width, img.height);
-          const scale = size > maxSize ? maxSize / size : 1;
-          const width = img.width * scale;
-          const height = img.height * scale;
+          // const maxCanvasSize = 1024;
+          const maxCanvasSize = 512; // 512px for smaller QR codes
+          const imgAspect = img.width / img.height;
+          let width, height;
+
+          if (imgAspect >= 1) {
+            width = maxCanvasSize;
+            height = maxCanvasSize / imgAspect;
+          } else {
+            height = maxCanvasSize;
+            width = maxCanvasSize * imgAspect;
+          }
 
           this.canvas.width = width;
           this.canvas.height = height;
+          this.canvas.style.width = `${width}px`;
+          this.canvas.style.height = `${height}px`;
 
-          const offsetX = (width - img.width * scale) / 2;
-          const offsetY = (height - img.height * scale) / 2;
-
+          // Draw background color
           ctx.fillStyle = "#121212";
           ctx.fillRect(0, 0, width, height);
 
+          // Draw semi-transparent background image
           ctx.globalAlpha = 0.25;
-          ctx.drawImage(img, offsetX, offsetY, img.width * scale, img.height * scale);
+          ctx.drawImage(img, 0, 0, width, height);
           ctx.globalAlpha = 1.0;
 
+          // Draw QR code on top using a temporary canvas
           const tempCanvas = document.createElement("canvas");
           tempCanvas.width = width;
           tempCanvas.height = height;
 
-          const mergedOptions = {
+          QRCode.toCanvas(tempCanvas, this.data, {
             ...this.options,
             width: width,
             color: {
               dark: this.options.color?.dark || '#00FF0077',
               light: '#00000000'
             }
-          };
-
-          QRCode.toCanvas(tempCanvas, this.data, mergedOptions, (err) => {
+          }, (err) => {
             if (err) {
               console.error(err);
             } else {
@@ -133,8 +141,7 @@
               light: '#00000000'
             }
           }
-        // ).render(downloadPNG); // Tainted canvases may not be exported.
-        ).render(); 
+        ).render(); // Do not call downloadPNG if the canvas is tainted
       }
     };
   </script>

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
           if (blob) {
             const newCid = await blobToCID(blob);
             console.log("New CID:", newCid);
-            const newUrl = `${window.location.origin}?id=${encodeURIComponent(newCid)}&src=${encodeURIComponent(this.data)}`;            console.log("New URL:", newUrl);
+            const newUrl = `${window.location.origin}?cid=${encodeURIComponent(newCid)}&src=${encodeURIComponent(this.data)}`;            console.log("New URL:", newUrl);
             // // Redirect to the new URL
             window.location.href = newUrl;
           }

--- a/index.html
+++ b/index.html
@@ -135,9 +135,10 @@
             const newCid = await blobToCID(blob);
             console.log("New CID:", newCid);
             const newUrl = `${window.location.origin}?cid=${encodeURIComponent(newCid)}&src=${encodeURIComponent(this.data)}`;            console.log("New URL:", newUrl);
-            // // Redirect to the new URL
-            window.location.href = newUrl;
-          }
+            // Make a dramatic pause and then redirect to the new URL
+            setTimeout(() => {
+              window.location.href = newUrl;
+            }, 5000);          }
         }, "image/png");
       }
     }

--- a/index.html
+++ b/index.html
@@ -28,12 +28,21 @@
         this.data = data;
         this.options = options;
       }
-
+    
       render(callback) {
         QRCode.toCanvas(this.canvas, this.data, this.options, (err) => {
           if (err) console.error(err);
           else if (callback) callback();
         });
+      }
+    
+      download() {
+        setTimeout(() => {
+          const link = document.createElement("a");
+          link.download = "viralqrcode.png";
+          link.href = this.canvas.toDataURL("image/png");
+          link.click();
+        }, 200);
       }
     }
 
@@ -99,10 +108,6 @@
           });
         };
 
-        // img.onerror = () => {
-        //   console.error("Failed to load image from IPFS");
-        //   alert("Failed to load image from IPFS");
-        // };
         img.onerror = () => {
           console.error("Failed to load image from IPFS, falling back to plain QR code.");
           // Fallback: render plain QR code
@@ -112,16 +117,7 @@
               dark: "#00FF00",
               light: "#121212"
             }
-          // }).render(callback);
-          }).render(() => {
-            // Download PNG after rendering fallback QR code
-            setTimeout(() => {
-              const link = document.createElement("a");
-              link.download = "viralqrcode.png";
-              link.href = this.canvas.toDataURL("image/png");
-              link.click();
-            }, 200);
-          });
+          }).render((callback) => this.download());
         };
       }
     }
@@ -132,23 +128,15 @@
       const cid = params.get("cid");
       const data = window.location.href;
 
-      const downloadPNG = () => {
-        setTimeout(() => {
-          const link = document.createElement("a");
-          link.download = "viralqrcode.png";
-          link.href = canvas.toDataURL("image/png");
-          link.click();
-        }, 200);
-      };
-
       if (!cid) {
-        new QRCodeRenderer(canvas, data, {
+        const qr = new QRCodeRenderer(canvas, data, {
           margin: 2,
           color: {
             dark: "#00FF00",
             light: "#121212"
           }
-        }).render(downloadPNG);
+        });
+        qr.render(() => qr.download());
       } else {
         new ImageBackgroundQRCodeRenderer(
           canvas,
@@ -161,7 +149,7 @@
               light: '#00000000'
             }
           }
-        ).render(); // Do not call downloadPNG if the canvas is tainted
+        ).render(); // Do not call download if the canvas is tainted
       }
     };
   </script>


### PR DESCRIPTION
This update improves reliability and user experience for QR code generation with NFT backgrounds. The canvas size is clamped and aspect ratio preserved to prevent oversized images. If loading the NFT image from IPFS fails, the app silently falls back to rendering a plain QR code with no alerts or UI messages. When generating a new composite QR+background image, a SHA-256 hash of the image blob is used as a pseudo-CID. After rendering, the app waits five seconds before automatically redirecting to a new URL containing the generated CID and a base64-encoded reference to the original data. 